### PR TITLE
Add maven.geotoolkit.org maven repository

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,7 @@ resolvers += "Unidata maven repository" at "http://artifacts.unidata.ucar.edu/co
 resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"
 resolvers += "spray repo" at "http://repo.spray.io"
 resolvers += "Artima Maven Repository" at "http://repo.artima.com/releases"
+resolvers += "Geotoolkit" at "http://maven.geotoolkit.org/"
 
 libraryDependencies ++= Dependencies.scala
 


### PR DESCRIPTION
`sbt publishLocal` didn't run for me from a fresh checkout because `javax.media.jai_core` couldn't be resolved. This JAR is not even currently available on Maven Central (see  [this thread](http://stackoverflow.com/questions/26993105/i-get-an-error-downloading-javax-media-jai-core1-1-3-from-maven-central)), so I added the [Geotoolkit repository](http://maven.geotoolkit.org/) to resolve the JAR from there.
